### PR TITLE
Completely remove `entry.asm`

### DIFF
--- a/os/src/entry.asm
+++ b/os/src/entry.asm
@@ -1,8 +1,0 @@
-.section .bss.stack
-
-	.global boot_stack_lower_bound
-boot_stack_lower_bound:
-	.space 0x00080000 # 512 KB
-
-	.global boot_stack_top
-boot_stack_top:

--- a/os/src/linker-qemu.ld
+++ b/os/src/linker-qemu.ld
@@ -33,6 +33,11 @@ SECTIONS
     edata = .;
     .bss : {
         *(.bss.stack)
+        PROVIDE(boot_stack_bottom = .);
+        . = ALIGN(4K);
+        . += 0x00080000;
+        . = ALIGN(4K);
+        PROVIDE(boot_stack_top = .);
         sbss = .;
         *(.bss .bss.*)
         *(.sbss .sbss.*)

--- a/os/src/main.rs
+++ b/os/src/main.rs
@@ -25,7 +25,6 @@ pub mod task;
 mod timer;
 pub mod trap;
 
-global_asm!(include_str!("entry.asm"));
 global_asm!(include_str!("link_app.S"));
 
 #[no_mangle]
@@ -41,7 +40,7 @@ unsafe extern "C" fn _start() -> ! {
         "la sp, boot_stack_top",
         // # Make fp 0 so that stack trace knows where to stop
         "xor fp, fp, fp",
-        "j __kernel_start_main", 
+        "j __kernel_start_main",
         options(noreturn)
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced memory allocation for the stack in the operating system to improve alignment and define clear stack boundaries.
- **Bug Fixes**
	- Removed an outdated assembly directive and refined the spacing in the assembly code to ensure more reliable system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->