### PR TITLE
chore: Add rustfmt format check in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup toolchains
         run: |
           rustup toolchain install nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,20 @@ jobs:
 
       - name: Cargo Clippy
         run: make clippy
+
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup toolchains
+        run: |
+          rustup toolchain install nightly
+          rustup target add riscv64gc-unknown-none-elf --toolchain nightly
+          rustup override set nightly
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt --toolchain nightly
+
+      - name: Format check
+        run: make format-check
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,6 @@ jobs:
       - name: Install rustfmt
         run: rustup component add rustfmt --toolchain nightly
 
+        # Only run format check in kernel crate Since user crate will be removed in the future
       - name: Format check
-        run: make format-check
-          
+        run: cd os && cargo fmt --check

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,9 @@ clippy: clippy-user clippy-os
 clippy-%:
 	cd $* && cargo clippy --all-features
 
+# Only run format check in kernel crate Since user crate will be removed in the future
+format-check:
+	@cd os && cargo fmt --check
+
 %:
 	@cd os && make -s $@

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,5 @@ clippy: clippy-user clippy-os
 clippy-%:
 	cd $* && cargo clippy --all-features
 
-# Only run format check in kernel crate Since user crate will be removed in the future
-format-check:
-	@cd os && cargo fmt --check
-
 %:
 	@cd os && make -s $@


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Implemented a new format-check job in the continuous integration workflow to ensure code formatting standards.
	- Added a `format-check` target in the Makefile for code quality checks in the kernel crate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->